### PR TITLE
connection query without content is now possible

### DIFF
--- a/src/main/java/org/crygier/graphql/ExtendedJpaDataFetcher.java
+++ b/src/main/java/org/crygier/graphql/ExtendedJpaDataFetcher.java
@@ -42,10 +42,19 @@ public class ExtendedJpaDataFetcher extends JpaDataFetcher {
             result.put("content", getQuery(environment, contentSelection.get()).setMaxResults(pageInformation.size).setFirstResult((pageInformation.page - 1) * pageInformation.size).getResultList());
 
         if (totalElementsSelection.isPresent() || totalPagesSelection.isPresent()) {
-            Long totalElements = getCountQuery(environment, contentSelection.get()).getSingleResult();
 
-            result.put("totalElements", totalElements);
-            result.put("totalPages", ((Double) Math.ceil(totalElements / (double) pageInformation.size)).longValue());
+            if(contentSelection.isPresent()) {
+                Long totalElements = getCountQuery(environment, contentSelection.get()).getSingleResult();
+
+                result.put("totalElements", totalElements);
+                result.put("totalPages", ((Double) Math.ceil(totalElements / (double) pageInformation.size)).longValue());
+            } else {
+                // if no "content" was selected an empty Field can be used
+                Long totalElements = getCountQuery(environment, new Field()).getSingleResult();
+
+                result.put("totalElements", totalElements);
+                result.put("totalPages", ((Double) Math.ceil(totalElements / (double) pageInformation.size)).longValue());
+            }
         }
 
         return result;

--- a/src/main/java/org/crygier/graphql/ExtendedJpaDataFetcher.java
+++ b/src/main/java/org/crygier/graphql/ExtendedJpaDataFetcher.java
@@ -42,19 +42,13 @@ public class ExtendedJpaDataFetcher extends JpaDataFetcher {
             result.put("content", getQuery(environment, contentSelection.get()).setMaxResults(pageInformation.size).setFirstResult((pageInformation.page - 1) * pageInformation.size).getResultList());
 
         if (totalElementsSelection.isPresent() || totalPagesSelection.isPresent()) {
+            final Long totalElements = contentSelection
+                    .map(contentField -> getCountQuery(environment, contentField).getSingleResult())
+                    // if no "content" was selected an empty Field can be used
+                    .orElseGet(() -> getCountQuery(environment, new Field()).getSingleResult());
 
-            if(contentSelection.isPresent()) {
-                Long totalElements = getCountQuery(environment, contentSelection.get()).getSingleResult();
-
-                result.put("totalElements", totalElements);
-                result.put("totalPages", ((Double) Math.ceil(totalElements / (double) pageInformation.size)).longValue());
-            } else {
-                // if no "content" was selected an empty Field can be used
-                Long totalElements = getCountQuery(environment, new Field()).getSingleResult();
-
-                result.put("totalElements", totalElements);
-                result.put("totalPages", ((Double) Math.ceil(totalElements / (double) pageInformation.size)).longValue());
-            }
+            result.put("totalElements", totalElements);
+            result.put("totalPages", ((Double) Math.ceil(totalElements / (double) pageInformation.size)).longValue());
         }
 
         return result;

--- a/src/test/groovy/org/crygier/graphql/StarwarsQueryExecutorTest.groovy
+++ b/src/test/groovy/org/crygier/graphql/StarwarsQueryExecutorTest.groovy
@@ -1,6 +1,5 @@
 package org.crygier.graphql
 
-import groovy.json.JsonOutput
 import org.crygier.graphql.model.starwars.Episode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.SpringApplicationContextLoader
@@ -256,6 +255,31 @@ class StarwarsQueryExecutorTest extends Specification {
                                 [ name: 'Darth Vader' ],
                                 [ name: 'Luke Skywalker' ]
                         ]
+                ]
+        ]
+
+        when:
+        def result = executor.execute(query).data
+
+        then:
+        result == expected
+    }
+
+    def 'Pagination without content'() {
+        given:
+        def query = '''
+        {
+            HumanConnection(paginationRequest: { page: 1, size: 2}) {
+                totalPages
+                totalElements
+            }
+        }
+        '''
+
+        def expected = [
+                HumanConnection: [
+                        totalPages: 3,
+                        totalElements: 5
                 ]
         ]
 


### PR DESCRIPTION
Fix for #14 
With this fix you can write a queries like:

```
{
    HumanConnection(paginationRequest: { page: 1, size: 2}) {
        totalPages
        totalElements
    }
}
```
This can be useful if you are only interested in the number of elements and pages but don't need any content. 

The implementation uses the fact that in the criteria query a list of `Predicate` is created based on `Field.getAttributes()`. I'm passing an empty `Field` which results in an empty predicate list. 
