### PR TITLE
Build against graphql-java 2.4.0; Remove deprecated API usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ configurations {
 }
 
 dependencies {
-    compile 'com.graphql-java:graphql-java:2.1.0'
+    compile 'com.graphql-java:graphql-java:2.4.0'
     compile 'javax.transaction:javax.transaction-api:1.2'
     provided 'org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final'
 

--- a/src/main/java/org/crygier/graphql/GraphQLExecutor.java
+++ b/src/main/java/org/crygier/graphql/GraphQLExecutor.java
@@ -24,7 +24,7 @@ public class GraphQLExecutor {
     @PostConstruct
     protected void createGraphQL() {
         if (entityManager != null)
-            this.graphQL = new GraphQL(new GraphQLSchemaBuilder(entityManager).getGraphQLSchema());
+            this.graphQL = GraphQL.newGraphQL(new GraphQLSchemaBuilder(entityManager).getGraphQLSchema()).build();
     }
 
     @Transactional


### PR DESCRIPTION
Here's a small update to 2.4.0; I'd wanted to upgrade to graphql-java 3.0.0, but I'm getting an error I don't know how to resolve for now:

```
java.lang.IllegalStateException: Failed to load ApplicationContext
	at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:124)
...
Caused by: graphql.AssertException: All types within a GraphQL schema must have unique names. No two provided types may have the same name.
No provided type may have a name which conflicts with any built in types (including Scalar and Introspection types).
You have redefined the type 'Episode' from being a 'GraphQLEnumType' to a 'GraphQLEnumType'
	at graphql.schema.SchemaUtil.assertTypeUniqueness(SchemaUtil.java:86)
	at graphql.schema.SchemaUtil.collectTypes(SchemaUtil.java:50)
	at graphql.schema.SchemaUtil.collectTypes(SchemaUtil.java:48)
	at graphql.schema.SchemaUtil.collectTypesForObjects(SchemaUtil.java:130)
	at graphql.schema.SchemaUtil.collectTypes(SchemaUtil.java:56)
	at graphql.schema.SchemaUtil.allTypes(SchemaUtil.java:153)
	at graphql.schema.GraphQLSchema.<init>(GraphQLSchema.java:42)
	at graphql.schema.GraphQLSchema$Builder.build(GraphQLSchema.java:130)
	at graphql.schema.GraphQLSchema$Builder.build(GraphQLSchema.java:125)
	at org.crygier.graphql.GraphQLSchemaBuilder.getGraphQLSchema(GraphQLSchemaBuilder.java:37)
	at org.crygier.graphql.GraphQLExecutor.createGraphQL(GraphQLExecutor.java:27)
...
````
Caused by repeated invocations of this function for `org.crygier.graphql.model.starwars.Episode`:
https://github.com/jcrygier/graphql-jpa/blob/master/src/main/java/org/crygier/graphql/GraphQLSchemaBuilder.java#L218

Any suggestions there @jcrygier ? Otherwise fine to merge this pull request already.