### PR TITLE
Basic support for @Embeddable and @EmbeddedId annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 .project
 .settings/
 classes/
+out/

--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,10 @@ dependencies {
     compile 'javax.transaction:javax.transaction-api:1.2'
     provided 'org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final'
 
-    testCompile "org.springframework.boot:spring-boot-starter:1.3.1.RELEASE"
-    testCompile "org.springframework.boot:spring-boot-starter-test:1.3.1.RELEASE"
-    testCompile "org.springframework.boot:spring-boot-starter-data-jpa:1.3.1.RELEASE"
-    testCompile "org.springframework.boot:spring-boot-starter-web:1.3.1.RELEASE"
+    testCompile "org.springframework.boot:spring-boot-starter:1.5.1.RELEASE"
+    testCompile "org.springframework.boot:spring-boot-starter-test:1.5.1.RELEASE"
+    testCompile "org.springframework.boot:spring-boot-starter-data-jpa:1.5.1.RELEASE"
+    testCompile "org.springframework.boot:spring-boot-starter-web:1.5.1.RELEASE"
     testCompile 'junit:junit:4.11'
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
     testCompile 'org.spockframework:spock-spring:1.0-groovy-2.4'

--- a/src/main/java/org/crygier/graphql/GraphQLSchemaBuilder.java
+++ b/src/main/java/org/crygier/graphql/GraphQLSchemaBuilder.java
@@ -1,42 +1,21 @@
 package org.crygier.graphql;
 
 import graphql.Scalars;
-import graphql.schema.GraphQLArgument;
-import graphql.schema.GraphQLEnumType;
-import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLInputObjectField;
-import graphql.schema.GraphQLInputObjectType;
-import graphql.schema.GraphQLInputType;
-import graphql.schema.GraphQLList;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLOutputType;
-import graphql.schema.GraphQLSchema;
-import graphql.schema.GraphQLType;
-import graphql.schema.GraphQLTypeReference;
+import graphql.schema.*;
 import org.crygier.graphql.annotation.GraphQLIgnore;
 import org.crygier.graphql.annotation.SchemaDocumentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.persistence.EntityManager;
-import javax.persistence.metamodel.Attribute;
-import javax.persistence.metamodel.EntityType;
-import javax.persistence.metamodel.PluralAttribute;
-import javax.persistence.metamodel.SingularAttribute;
-import javax.persistence.metamodel.Type;
+import javax.persistence.metamodel.*;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -72,10 +51,10 @@ public class GraphQLSchemaBuilder {
     private GraphQLFieldDefinition getQueryFieldDefinition(EntityType<?> entityType) {
         return GraphQLFieldDefinition.newFieldDefinition()
                 .name(entityType.getName())
-                .description(getSchemaDocumentation( entityType.getJavaType()))
+                .description(getSchemaDocumentation(entityType.getJavaType()))
                 .type(new GraphQLList(getObjectType(entityType)))
                 .dataFetcher(new JpaDataFetcher(entityManager, entityType))
-                .argument(entityType.getAttributes().stream().filter(this::isValidInput).filter(this::isNotIgnored).map(this::getArgument).collect(Collectors.toList()))
+                .argument(entityType.getAttributes().stream().filter(this::isValidInput).filter(this::isNotIgnored).flatMap(this::getArgument).collect(Collectors.toList()))
                 .build();
     }
 
@@ -97,17 +76,13 @@ public class GraphQLSchemaBuilder {
                 .build();
     }
 
-    private GraphQLArgument getArgument(Attribute attribute) {
-        GraphQLType type = getAttributeType(attribute);
-
-        if (type instanceof GraphQLInputType) {
-            return GraphQLArgument.newArgument()
-                    .name(attribute.getName())
-                    .type((GraphQLInputType) type)
-                    .build();
-        }
-
-        throw new IllegalArgumentException("Attribute " + attribute + " cannot be mapped as an Input Argument");
+    private Stream<GraphQLArgument> getArgument(Attribute attribute) {
+        return getAttributeType(attribute)
+                .filter(typ -> typ instanceof GraphQLInputType)
+                .map(type -> GraphQLArgument.newArgument()
+                        .name(attribute.getName())
+                        .type((GraphQLInputType) type)
+                        .build());
     }
 
     private GraphQLObjectType getObjectType(EntityType<?> entityType) {
@@ -116,8 +91,8 @@ public class GraphQLSchemaBuilder {
 
         GraphQLObjectType answer = GraphQLObjectType.newObject()
                 .name(entityType.getName())
-                .description(getSchemaDocumentation( entityType.getJavaType()))
-                .fields(entityType.getAttributes().stream().filter(this::isNotIgnored).map(this::getObjectField).collect(Collectors.toList()))
+                .description(getSchemaDocumentation(entityType.getJavaType()))
+                .fields(entityType.getAttributes().stream().filter(this::isNotIgnored).flatMap(this::getObjectField).collect(Collectors.toList()))
                 .build();
 
         entityCache.put(entityType, answer);
@@ -125,32 +100,30 @@ public class GraphQLSchemaBuilder {
         return answer;
     }
 
-    private GraphQLFieldDefinition getObjectField(Attribute attribute) {
-        GraphQLType type = getAttributeType(attribute);
+    private Stream<GraphQLFieldDefinition> getObjectField(Attribute attribute) {
+        return getAttributeType(attribute)
+                .filter(type -> type instanceof GraphQLOutputType)
+                .map(type -> {
+                    List<GraphQLArgument> arguments = new ArrayList<>();
+                    arguments.add(GraphQLArgument.newArgument().name("orderBy").type(orderByDirectionEnum).build());            // Always add the orderBy argument
 
-        if (type instanceof GraphQLOutputType) {
-            List<GraphQLArgument> arguments = new ArrayList<>();
-            arguments.add(GraphQLArgument.newArgument().name("orderBy").type(orderByDirectionEnum).build());            // Always add the orderBy argument
+                    // Get the fields that can be queried on (i.e. Simple Types, no Sub-Objects)
+                    if (attribute instanceof SingularAttribute && attribute.getPersistentAttributeType() != Attribute.PersistentAttributeType.BASIC) {
+                        ManagedType foreignType = (ManagedType) ((SingularAttribute) attribute).getType();
+                        Stream<Attribute> attributes = findBasicAttributes(foreignType.getAttributes());
 
-            // Get the fields that can be queried on (i.e. Simple Types, no Sub-Objects)
-            if (attribute instanceof SingularAttribute && attribute.getPersistentAttributeType() != Attribute.PersistentAttributeType.BASIC) {
-                EntityType foreignType = (EntityType) ((SingularAttribute) attribute).getType();
-                Stream<Attribute> attributes = findBasicAttributes(foreignType.getAttributes());
+                        attributes.forEach(it -> {
+                            arguments.add(GraphQLArgument.newArgument().name(it.getName()).type((GraphQLInputType) getAttributeType(it).findFirst().get()).build());
+                        });
+                    }
 
-                attributes.forEach(it -> {
-                    arguments.add(GraphQLArgument.newArgument().name(it.getName()).type((GraphQLInputType) getAttributeType(it)).build());
+                    return GraphQLFieldDefinition.newFieldDefinition()
+                            .name(attribute.getName())
+                            .description(getSchemaDocumentation(attribute.getJavaMember()))
+                            .type((GraphQLOutputType) type)
+                            .argument(arguments)
+                            .build();
                 });
-            }
-
-            return GraphQLFieldDefinition.newFieldDefinition()
-                    .name(attribute.getName())
-                    .description(getSchemaDocumentation(attribute.getJavaMember()))
-                    .type((GraphQLOutputType) type)
-                    .argument(arguments)
-                    .build();
-        }
-
-        throw new IllegalArgumentException("Attribute " + attribute + " cannot be mapped as an Output Argument");
     }
 
     private Stream<Attribute> findBasicAttributes(Collection<Attribute> attributes) {
@@ -186,33 +159,37 @@ public class GraphQLSchemaBuilder {
         }
 
         throw new UnsupportedOperationException(
-                "Class could not be mapped to GraphQL: '"+ javaType.getClass().getTypeName() +"'");
+                "Class could not be mapped to GraphQL: '" + javaType.getClass().getTypeName() + "'");
     }
 
-    private GraphQLType getAttributeType(Attribute attribute) {
+    private Stream<GraphQLType> getAttributeType(Attribute attribute) {
         if (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.BASIC) {
             try {
-                return getBasicAttributeType(attribute.getJavaType());
+                return Stream.of(getBasicAttributeType(attribute.getJavaType()));
             } catch (UnsupportedOperationException e) {
                 //fall through to the exception below
                 //which is more useful because it also contains the declaring member
             }
         } else if (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ONE_TO_MANY || attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.MANY_TO_MANY) {
             EntityType foreignType = (EntityType) ((PluralAttribute) attribute).getElementType();
-            return new GraphQLList(new GraphQLTypeReference(foreignType.getName()));
+            return Stream.of(new GraphQLList(new GraphQLTypeReference(foreignType.getName())));
         } else if (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.MANY_TO_ONE || attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ONE_TO_ONE) {
             EntityType foreignType = (EntityType) ((SingularAttribute) attribute).getType();
-            return new GraphQLTypeReference(foreignType.getName());
+            return Stream.of(new GraphQLTypeReference(foreignType.getName()));
         } else if (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.ELEMENT_COLLECTION) {
             Type foreignType = ((PluralAttribute) attribute).getElementType();
-            return new GraphQLList(getTypeFromJavaType(foreignType.getJavaType()));
+            return Stream.of(new GraphQLList(getTypeFromJavaType(foreignType.getJavaType())));
+        } else if (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.EMBEDDED) {
+            EmbeddableType embeddableType = (EmbeddableType) ((SingularAttribute) attribute).getType();
+            Stream<Attribute> s = (Stream<Attribute>) embeddableType.getAttributes().stream();
+            return s.flatMap(this::getAttributeType);
         }
 
         final String declaringType = attribute.getDeclaringType().getJavaType().getName(); // fully qualified name of the entity class
         final String declaringMember = attribute.getJavaMember().getName(); // field name in the entity class
 
         throw new UnsupportedOperationException(
-                "Attribute could not be mapped to GraphQL: field '" + declaringMember + "' of entity class '"+ declaringType +"'");
+                "Attribute could not be mapped to GraphQL: field '" + declaringMember + "' of entity class '" + declaringType + "'");
     }
 
     private boolean isValidInput(Attribute attribute) {
@@ -265,7 +242,7 @@ public class GraphQLSchemaBuilder {
 
             GraphQLEnumType.Builder enumBuilder = GraphQLEnumType.newEnum().name(clazz.getSimpleName());
             int ordinal = 0;
-            for (Enum enumValue : ((Class<Enum>)clazz).getEnumConstants())
+            for (Enum enumValue : ((Class<Enum>) clazz).getEnumConstants())
                 enumBuilder.value(enumValue.name(), ordinal++);
 
             GraphQLType answer = enumBuilder.build();
@@ -298,11 +275,11 @@ public class GraphQLSchemaBuilder {
             GraphQLArgument.newArgument()
                     .name(PAGINATION_REQUEST_PARAM_NAME)
                     .type(GraphQLInputObjectType.newInputObject()
-                                    .name("PaginationObject")
-                                    .description("Query object for Pagination Requests, specifying the requested page, and that page's size.\n\nNOTE: 'page' parameter is 1-indexed, NOT 0-indexed.\n\nExample: paginationRequest { page: 1, size: 20 }")
-                                    .field(GraphQLInputObjectField.newInputObjectField().name("page").description("Which page should be returned, starting with 1 (1-indexed)").type(Scalars.GraphQLInt).build())
-                                    .field(GraphQLInputObjectField.newInputObjectField().name("size").description("How many results should this page contain").type(Scalars.GraphQLInt).build())
-                                    .build()
+                            .name("PaginationObject")
+                            .description("Query object for Pagination Requests, specifying the requested page, and that page's size.\n\nNOTE: 'page' parameter is 1-indexed, NOT 0-indexed.\n\nExample: paginationRequest { page: 1, size: 20 }")
+                            .field(GraphQLInputObjectField.newInputObjectField().name("page").description("Which page should be returned, starting with 1 (1-indexed)").type(Scalars.GraphQLInt).build())
+                            .field(GraphQLInputObjectField.newInputObjectField().name("size").description("How many results should this page contain").type(Scalars.GraphQLInt).build())
+                            .build()
                     ).build();
 
     private static final GraphQLEnumType orderByDirectionEnum =

--- a/src/main/java/org/crygier/graphql/GraphQLSchemaBuilder.java
+++ b/src/main/java/org/crygier/graphql/GraphQLSchemaBuilder.java
@@ -79,7 +79,8 @@ public class GraphQLSchemaBuilder {
     private Stream<GraphQLArgument> getArgument(Attribute attribute) {
         return getAttributeType(attribute)
                 .filter(type -> type instanceof GraphQLInputType)
-                .filter(type -> attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.EMBEDDED && type instanceof GraphQLScalarType)
+                .filter(type -> attribute.getPersistentAttributeType() != Attribute.PersistentAttributeType.EMBEDDED ||
+                        (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.EMBEDDED && type instanceof GraphQLScalarType))
                 .map(type -> {
                     String name;
                     if (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.EMBEDDED) {

--- a/src/main/java/org/crygier/graphql/GraphQLSchemaBuilder.java
+++ b/src/main/java/org/crygier/graphql/GraphQLSchemaBuilder.java
@@ -48,7 +48,7 @@ public class GraphQLSchemaBuilder {
         return queryType.build();
     }
 
-    private GraphQLFieldDefinition getQueryFieldDefinition(EntityType<?> entityType) {
+    GraphQLFieldDefinition getQueryFieldDefinition(EntityType<?> entityType) {
         return GraphQLFieldDefinition.newFieldDefinition()
                 .name(entityType.getName())
                 .description(getSchemaDocumentation(entityType.getJavaType()))
@@ -85,7 +85,7 @@ public class GraphQLSchemaBuilder {
                         .build());
     }
 
-    private GraphQLObjectType getObjectType(EntityType<?> entityType) {
+    GraphQLObjectType getObjectType(EntityType<?> entityType) {
         if (entityCache.containsKey(entityType))
             return entityCache.get(entityType);
 
@@ -108,17 +108,29 @@ public class GraphQLSchemaBuilder {
                     arguments.add(GraphQLArgument.newArgument().name("orderBy").type(orderByDirectionEnum).build());            // Always add the orderBy argument
 
                     // Get the fields that can be queried on (i.e. Simple Types, no Sub-Objects)
-                    if (attribute instanceof SingularAttribute && attribute.getPersistentAttributeType() != Attribute.PersistentAttributeType.BASIC) {
+                    if (attribute instanceof SingularAttribute
+                            && attribute.getPersistentAttributeType() != Attribute.PersistentAttributeType.BASIC) {
                         ManagedType foreignType = (ManagedType) ((SingularAttribute) attribute).getType();
+
                         Stream<Attribute> attributes = findBasicAttributes(foreignType.getAttributes());
 
                         attributes.forEach(it -> {
-                            arguments.add(GraphQLArgument.newArgument().name(it.getName()).type((GraphQLInputType) getAttributeType(it).findFirst().get()).build());
+                            arguments.add(GraphQLArgument.newArgument()
+                                    .name(it.getName())
+                                    .type((GraphQLInputType) getAttributeType(it).findFirst().get())
+                                    .build());
                         });
                     }
 
+                    String name;
+                    if (attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.EMBEDDED) {
+                        name = type.getName();
+                    } else {
+                        name = attribute.getName();
+                    }
+
                     return GraphQLFieldDefinition.newFieldDefinition()
-                            .name(attribute.getName())
+                            .name(name)
                             .description(getSchemaDocumentation(attribute.getJavaMember()))
                             .type((GraphQLOutputType) type)
                             .argument(arguments)

--- a/src/test/groovy/org/crygier/graphql/EmbeddedSchemaBuildTest.groovy
+++ b/src/test/groovy/org/crygier/graphql/EmbeddedSchemaBuildTest.groovy
@@ -1,0 +1,35 @@
+package org.crygier.graphql
+
+import graphql.schema.GraphQLObjectType
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootContextLoader
+import org.springframework.context.annotation.Configuration
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+
+import javax.persistence.EntityManager
+import javax.persistence.metamodel.EntityType
+
+@Configuration
+@ContextConfiguration(loader = SpringBootContextLoader, classes = TestApplication)
+class EmbeddedSchemaBuildTest extends Specification {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private GraphQLSchemaBuilder builder;
+
+    void setup() {
+        builder = new GraphQLSchemaBuilder(entityManager);
+    }
+
+    def 'Correctly flattens embedded keys into two distinct fields'() {
+        when:
+        def embeddingEntity = entityManager.getMetamodel().getEntities().stream().filter { e -> e.name == "EmbeddingTest"}.findFirst().get()
+        def graphQlObject = builder.getObjectType(embeddingEntity)
+
+        then:
+        graphQlObject.fieldDefinitions.size() == 2
+    }
+
+}

--- a/src/test/groovy/org/crygier/graphql/EmbeddedSchemaBuildTest.groovy
+++ b/src/test/groovy/org/crygier/graphql/EmbeddedSchemaBuildTest.groovy
@@ -9,6 +9,7 @@ import spock.lang.Specification
 
 import javax.persistence.EntityManager
 import javax.persistence.metamodel.EntityType
+import java.util.stream.Collectors
 
 @Configuration
 @ContextConfiguration(loader = SpringBootContextLoader, classes = TestApplication)
@@ -29,7 +30,24 @@ class EmbeddedSchemaBuildTest extends Specification {
         def graphQlObject = builder.getObjectType(embeddingEntity)
 
         then:
-        graphQlObject.fieldDefinitions.size() == 2
+        graphQlObject.fieldDefinitions.size() == 3
+    }
+
+    def 'Correctly extract embedded basic query fields'() {
+        when:
+        def embeddingEntity = entityManager.getMetamodel().getEntities().stream().filter { e -> e.name == "EmbeddingTest"}.findFirst().get()
+        def graphQlFieldDefinition = builder.getQueryFieldDefinition(embeddingEntity)
+
+        then:
+        graphQlFieldDefinition.arguments.size() == 1
+    }
+
+    def 'Correctly extract a whole moddel with embeddings'() {
+        when:
+        def q = builder.getQueryType()
+
+        then:
+        true
     }
 
 }

--- a/src/test/groovy/org/crygier/graphql/StarwarsQueryExecutorTest.groovy
+++ b/src/test/groovy/org/crygier/graphql/StarwarsQueryExecutorTest.groovy
@@ -2,7 +2,7 @@ package org.crygier.graphql
 
 import org.crygier.graphql.model.starwars.Episode
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.SpringApplicationContextLoader
+import org.springframework.boot.test.context.SpringBootContextLoader
 import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.transaction.annotation.Transactional
@@ -11,7 +11,7 @@ import spock.lang.Specification
 import javax.persistence.EntityManager
 
 @Configuration
-@ContextConfiguration(loader = SpringApplicationContextLoader, classes = TestApplication)
+@ContextConfiguration(loader = SpringBootContextLoader, classes = TestApplication)
 class StarwarsQueryExecutorTest extends Specification {
 
     @Autowired

--- a/src/test/groovy/org/crygier/graphql/StarwarsSchemaBuildTest.groovy
+++ b/src/test/groovy/org/crygier/graphql/StarwarsSchemaBuildTest.groovy
@@ -3,7 +3,7 @@ package org.crygier.graphql
 import graphql.Scalars
 import graphql.schema.GraphQLSchema
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.SpringApplicationContextLoader
+import org.springframework.boot.test.context.SpringBootContextLoader
 import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.ContextConfiguration
 import spock.lang.Specification
@@ -11,7 +11,7 @@ import spock.lang.Specification
 import javax.persistence.EntityManager
 
 @Configuration
-@ContextConfiguration(loader = SpringApplicationContextLoader, classes = TestApplication)
+@ContextConfiguration(loader = SpringBootContextLoader, classes = TestApplication)
 class StarwarsSchemaBuildTest extends Specification {
 
     @Autowired

--- a/src/test/groovy/org/crygier/graphql/TestApplication.groovy
+++ b/src/test/groovy/org/crygier/graphql/TestApplication.groovy
@@ -3,7 +3,7 @@ package org.crygier.graphql
 import groovy.transform.CompileStatic
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.orm.jpa.EntityScan
+import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/src/test/groovy/org/crygier/graphql/ThingQueryExecutorTest.groovy
+++ b/src/test/groovy/org/crygier/graphql/ThingQueryExecutorTest.groovy
@@ -1,13 +1,13 @@
 package org.crygier.graphql
 
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.SpringApplicationContextLoader
+import org.springframework.boot.test.context.SpringBootContextLoader
 import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.ContextConfiguration
 import spock.lang.Specification
 
 @Configuration
-@ContextConfiguration(loader = SpringApplicationContextLoader, classes = TestApplication)
+@ContextConfiguration(loader = SpringBootContextLoader, classes = TestApplication)
 class ThingQueryExecutorTest extends Specification {
 
     @Autowired

--- a/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingId.java
+++ b/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingId.java
@@ -4,17 +4,31 @@ import org.crygier.graphql.annotation.GraphQLIgnore;
 import org.crygier.graphql.model.starwars.Character;
 import org.crygier.graphql.model.starwars.Episode;
 
-import javax.persistence.Embeddable;
-import javax.persistence.ManyToOne;
+import javax.persistence.*;
+import java.io.Serializable;
 
-//@GraphQLIgnore
-//@Embeddable
-public class EmbeddingId {
+@Embeddable
+class EmbeddingId implements Serializable {
 
-//    @ManyToOne
-    Character character;
+    @Basic
+    private int id;
 
-//    @ManyToOne
-    Episode episode;
+    public EmbeddingId(int id) {
+        this.id = id;
+    }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        EmbeddingId that = (EmbeddingId) o;
+
+        return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return id;
+    }
 }

--- a/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingId.java
+++ b/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingId.java
@@ -1,20 +1,27 @@
 package org.crygier.graphql.model.embeddings;
 
-import org.crygier.graphql.annotation.GraphQLIgnore;
 import org.crygier.graphql.model.starwars.Character;
 import org.crygier.graphql.model.starwars.Episode;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import java.io.Serializable;
 
 @Embeddable
 class EmbeddingId implements Serializable {
 
-    @Basic
-    private int id;
+    @ManyToOne
+    @JoinColumn(name = "character_id")
+    private Character character;
 
-    public EmbeddingId(int id) {
-        this.id = id;
+    @Column(name = "episode")
+    private Episode episode;
+
+    public EmbeddingId(Character character, Episode episode) {
+        this.character = character;
+        this.episode = episode;
     }
 
     @Override
@@ -24,11 +31,14 @@ class EmbeddingId implements Serializable {
 
         EmbeddingId that = (EmbeddingId) o;
 
-        return id == that.id;
+        if (character != null ? !character.equals(that.character) : that.character != null) return false;
+        return episode == that.episode;
     }
 
     @Override
     public int hashCode() {
-        return id;
+        int result = character != null ? character.hashCode() : 0;
+        result = 31 * result + (episode != null ? episode.hashCode() : 0);
+        return result;
     }
 }

--- a/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingId.java
+++ b/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingId.java
@@ -1,0 +1,20 @@
+package org.crygier.graphql.model.embeddings;
+
+import org.crygier.graphql.annotation.GraphQLIgnore;
+import org.crygier.graphql.model.starwars.Character;
+import org.crygier.graphql.model.starwars.Episode;
+
+import javax.persistence.Embeddable;
+import javax.persistence.ManyToOne;
+
+//@GraphQLIgnore
+//@Embeddable
+public class EmbeddingId {
+
+//    @ManyToOne
+    Character character;
+
+//    @ManyToOne
+    Episode episode;
+
+}

--- a/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingId.java
+++ b/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingId.java
@@ -19,9 +19,13 @@ class EmbeddingId implements Serializable {
     @Column(name = "episode")
     private Episode episode;
 
-    public EmbeddingId(Character character, Episode episode) {
+    @Column(name = "age")
+    private int age;
+
+    public EmbeddingId(Character character, Episode episode, int age) {
         this.character = character;
         this.episode = episode;
+        this.age = age;
     }
 
     @Override
@@ -31,6 +35,7 @@ class EmbeddingId implements Serializable {
 
         EmbeddingId that = (EmbeddingId) o;
 
+        if (age != that.age) return false;
         if (character != null ? !character.equals(that.character) : that.character != null) return false;
         return episode == that.episode;
     }
@@ -39,6 +44,7 @@ class EmbeddingId implements Serializable {
     public int hashCode() {
         int result = character != null ? character.hashCode() : 0;
         result = 31 * result + (episode != null ? episode.hashCode() : 0);
+        result = 31 * result + age;
         return result;
     }
 }

--- a/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingTest.java
+++ b/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingTest.java
@@ -5,14 +5,13 @@ import org.crygier.graphql.annotation.GraphQLIgnore;
 
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
+import javax.persistence.Id;
 
 @Entity
-@GraphQLIgnore
 @CompileStatic
 public class EmbeddingTest {
 
-//    @GraphQLIgnore
-//    @EmbeddedId
-//    EmbeddingId id;
+    @EmbeddedId
+    private EmbeddingId id;
 
 }

--- a/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingTest.java
+++ b/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingTest.java
@@ -2,6 +2,7 @@ package org.crygier.graphql.model.embeddings;
 
 import groovy.transform.CompileStatic;
 import org.crygier.graphql.annotation.GraphQLIgnore;
+import org.hibernate.annotations.Target;
 
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
@@ -12,6 +13,6 @@ import javax.persistence.Id;
 public class EmbeddingTest {
 
     @EmbeddedId
-    private EmbeddingId id;
+    private EmbeddingId embeddingId;
 
 }

--- a/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingTest.java
+++ b/src/test/groovy/org/crygier/graphql/model/embeddings/EmbeddingTest.java
@@ -1,0 +1,18 @@
+package org.crygier.graphql.model.embeddings;
+
+import groovy.transform.CompileStatic;
+import org.crygier.graphql.annotation.GraphQLIgnore;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+
+@Entity
+@GraphQLIgnore
+@CompileStatic
+public class EmbeddingTest {
+
+//    @GraphQLIgnore
+//    @EmbeddedId
+//    EmbeddingId id;
+
+}


### PR DESCRIPTION
Rudimentary support for @Embeddable annotations, where entity classes uses compound keys of either basic types or foreign objects. Fixes #26 
I added simple tests for embeddable annotations that should cover most simple uses.

Also ramped the spring version to 1.5.1.