### PR TITLE
Allowed manual manipulations of schema from the executor

### DIFF
--- a/src/main/java/org/crygier/graphql/GraphQLExecutor.java
+++ b/src/main/java/org/crygier/graphql/GraphQLExecutor.java
@@ -3,6 +3,7 @@ package org.crygier.graphql;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
@@ -10,22 +11,52 @@ import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 import java.util.Map;
 
+/**
+ * A GraphQL executor capable of constructing a {@link GraphQLSchema} from a JPA {@link EntityManager}. The executor
+ * uses the constructed schema to execute queries directly from the JPA data source.
+ * <p>
+ * If the executor is given a mutator function, it is feasible to manipulate the {@link GraphQLSchema}, introducing
+ * the option to add mutations, subscriptions etc.
+ */
 public class GraphQLExecutor {
 
     @Resource
     private EntityManager entityManager;
     private GraphQL graphQL;
+    private GraphQLSchema graphQLSchema;
+    private GraphQLSchema.Builder builder;
 
-    protected GraphQLExecutor() {}
+    protected GraphQLExecutor() {
+        createGraphQL();
+    }
+
+    /**
+     * Creates a read-only GraphQLExecutor using the entities discovered from the given {@link EntityManager}.
+     *
+     * @param entityManager The entity manager from which the JPA classes annotated with
+     *                      {@link javax.persistence.Entity} is extracted as {@link GraphQLSchema} objects.
+     */
     public GraphQLExecutor(EntityManager entityManager) {
         this.entityManager = entityManager;
         createGraphQL();
     }
 
     @PostConstruct
-    protected void createGraphQL() {
-        if (entityManager != null)
-            this.graphQL = GraphQL.newGraphQL(new GraphQLSchemaBuilder(entityManager).getGraphQLSchema()).build();
+    protected synchronized void createGraphQL() {
+        if (entityManager != null) {
+            if (builder == null) {
+                this.builder = new GraphQLSchemaBuilder(entityManager);
+            }
+            this.graphQLSchema = builder.build();
+            this.graphQL = GraphQL.newGraphQL(graphQLSchema).build();
+        }
+    }
+
+    /**
+     * @return The {@link GraphQLSchema} used by this executor.
+     */
+    public GraphQLSchema getGraphQLSchema() {
+        return graphQLSchema;
     }
 
     @Transactional
@@ -38,6 +69,36 @@ public class GraphQLExecutor {
         if (arguments == null)
             return graphQL.execute(query);
         return graphQL.execute(ExecutionInput.newExecutionInput().query(query).variables(arguments).build());
+    }
+
+    /**
+     * Gets the builder that was used to create the Schema that this executor is basing its query executions on. The
+     * builder can be used to update the executor with the {@link #updateSchema(GraphQLSchema.Builder)} method.
+     * @return An instance of a builder.
+     */
+    public GraphQLSchema.Builder getBuilder() {
+        return builder;
+    }
+
+    /**
+     * Returns the schema that this executor bases its queries on.
+     * @return An instance of a {@link GraphQLSchema}.
+     */
+    public GraphQLSchema getSchema() {
+        return graphQLSchema;
+    }
+
+    /**
+     * Uses the given builder to re-create and replace the {@link GraphQLSchema}
+     * that this executor uses to execute its queries.
+     *
+     * @param builder The builder to recreate the current {@link GraphQLSchema} and {@link GraphQL} instances.
+     * @return The same executor but with a new {@link GraphQL} schema.
+     */
+    public GraphQLExecutor updateSchema(GraphQLSchema.Builder builder) {
+        this.builder = builder;
+        createGraphQL();
+        return this;
     }
 
 }

--- a/src/main/java/org/crygier/graphql/GraphQLSchemaBuilder.java
+++ b/src/main/java/org/crygier/graphql/GraphQLSchemaBuilder.java
@@ -19,25 +19,39 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class GraphQLSchemaBuilder {
+/**
+ * A wrapper for the {@link GraphQLSchema.Builder}. In addition to exposing the traditional builder functionality,
+ * this class constructs an initial {@link GraphQLSchema} by scanning the given {@link EntityManager} for relevant
+ * JPA entities. This happens at construction time.
+ *
+ * Note: This class should not be accessed outside this library.
+ */
+public class GraphQLSchemaBuilder extends GraphQLSchema.Builder {
 
     public static final String PAGINATION_REQUEST_PARAM_NAME = "paginationRequest";
     private static final Logger log = LoggerFactory.getLogger(GraphQLSchemaBuilder.class);
 
-    private EntityManager entityManager;
+    private final EntityManager entityManager;
+    private final Map<Class, GraphQLType> classCache = new HashMap<>();
+    private final Map<EntityType, GraphQLObjectType> entityCache = new HashMap<>();
 
-    private Map<Class, GraphQLType> classCache = new HashMap<>();
-    private Map<EntityType, GraphQLObjectType> entityCache = new HashMap<>();
-
+    /**
+     * Initialises the builder with the given {@link EntityManager} from which we immediately start to scan for
+     * entities to include in the GraphQL schema.
+     * @param entityManager The manager containing the data models to include in the final GraphQL schema.
+     */
     public GraphQLSchemaBuilder(EntityManager entityManager) {
         this.entityManager = entityManager;
+        super.query(getQueryType());
     }
 
+    /**
+     * @deprecated Use {@link #build()} instead.
+     * @return A freshly built {@link GraphQLSchema}
+     */
+    @Deprecated()
     public GraphQLSchema getGraphQLSchema() {
-        GraphQLSchema.Builder schemaBuilder = GraphQLSchema.newSchema();
-        schemaBuilder.query(getQueryType());
-
-        return schemaBuilder.build();
+        return super.build();
     }
 
     GraphQLObjectType getQueryType() {

--- a/src/test/groovy/org/crygier/graphql/MutableQueryExecutorTest.groovy
+++ b/src/test/groovy/org/crygier/graphql/MutableQueryExecutorTest.groovy
@@ -1,0 +1,37 @@
+package org.crygier.graphql
+
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchema
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootContextLoader
+import org.springframework.context.annotation.Configuration
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+
+import static graphql.Scalars.GraphQLString
+
+@Configuration
+@ContextConfiguration(loader = SpringBootContextLoader, classes = TestApplication)
+class MutableQueryExecutorTest extends Specification {
+
+    @Autowired
+    private GraphQLExecutor executor;
+
+    private final GraphQLObjectType droidMutation = GraphQLObjectType.newObject()
+            .name("CreateDroidMutation")
+            .field(GraphQLFieldDefinition.newFieldDefinition()
+            .name("name")
+            .type(GraphQLString))
+            .build()
+
+    def 'Can add a schema mutation'() {
+        when:
+        GraphQLSchema.Builder builder = executor.getBuilder().mutation(droidMutation)
+        executor.updateSchema(builder)
+
+        then:
+        executor.getSchema().mutationType == droidMutation
+    }
+
+}

--- a/src/test/groovy/org/crygier/graphql/MutableSchemaBuildTest.groovy
+++ b/src/test/groovy/org/crygier/graphql/MutableSchemaBuildTest.groovy
@@ -1,0 +1,41 @@
+package org.crygier.graphql
+
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchema
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootContextLoader
+import org.springframework.context.annotation.Configuration
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+
+import javax.persistence.EntityManager
+
+import static graphql.Scalars.GraphQLString
+
+@Configuration
+@ContextConfiguration(loader = SpringBootContextLoader, classes = TestApplication)
+class MutableSchemaBuildTest extends Specification {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private GraphQLSchema schema;
+
+    private final GraphQLObjectType droidMutation = GraphQLObjectType.newObject()
+            .name("CreateDroidMutation")
+            .field(GraphQLFieldDefinition.newFieldDefinition()
+                .name("name")
+                .type(GraphQLString))
+            .build()
+
+    void setup() {
+        schema = new GraphQLSchemaBuilder(entityManager).mutation(droidMutation).build()
+    }
+
+    def 'Can add a schema mutation'() {
+        expect:
+        schema.mutationType == droidMutation
+    }
+
+}


### PR DESCRIPTION
Inspired by [this discussion](https://github.com/jcrygier/graphql-jpa/issues/19) I let the builder extend the GraphQLSchema.Builder class so it exposes regular builder methods.

I then exposed the builder (as a GraphQLSchema.Builder, not as a GraphQLSchemaBuilder) in the GraphQLExecutor to allow adding mutations runtime.

To keep the bean properties so the executor can be retained as autowired, I allowed the schema manipulations to happen post-construction. To address [lestranges comment](https://github.com/jcrygier/graphql-jpa/issues/19#issuecomment-294319273) this could pave the way for dependency injection (1) and hides the specific implementation of the GraphQLSchemaBuilder, so it can be renamed/refactored to what it actually is: a wrapper for the builder that automatically constructs a (initial) schema from JPA entities.

As a practical example, changing the schema with this PR could look something like this: 

    GraphQLSchema.Builder builder = executor.getBuilder().mutation(droidMutation)
    executor.updateSchema(builder)