### PR TITLE
Add java8 instant support.

### DIFF
--- a/src/main/java/org/crygier/graphql/GraphQLSchemaBuilder.java
+++ b/src/main/java/org/crygier/graphql/GraphQLSchemaBuilder.java
@@ -13,6 +13,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -207,6 +208,8 @@ public class GraphQLSchemaBuilder extends GraphQLSchema.Builder {
             return JavaScalars.GraphQLDate;
         else if (LocalDateTime.class.isAssignableFrom(javaType))
             return JavaScalars.GraphQLLocalDateTime;
+        else if (Instant.class.isAssignableFrom(javaType))
+            return JavaScalars.GraphQLInstant;
         else if (LocalDate.class.isAssignableFrom(javaType))
             return JavaScalars.GraphQLLocalDate;
         else if (javaType.isEnum()) {

--- a/src/main/java/org/crygier/graphql/JavaScalars.java
+++ b/src/main/java/org/crygier/graphql/JavaScalars.java
@@ -3,6 +3,7 @@ package org.crygier.graphql;
 import graphql.language.IntValue;
 import graphql.language.StringValue;
 import graphql.schema.Coercing;
+import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +65,38 @@ public class JavaScalars {
                 return null;
             }
         }
+    });
+
+    public static GraphQLScalarType GraphQLInstant = new GraphQLScalarType("Instant", "Date type", new Coercing<Instant, Long>() {
+
+        @Override
+        public Long serialize(Object input) {
+            if (input instanceof Instant) {
+                return ((Instant) input).getEpochSecond();
+            }
+            throw new CoercingSerializeException(
+                    "Expected type 'Instant' but was '" + input.getClass().getSimpleName() + "'.");
+        }
+
+        @Override
+        public Instant parseValue(Object input) {
+            if (input instanceof Long) {
+                return Instant.ofEpochSecond((Long) input);
+            } else if (input instanceof Integer) {
+                return Instant.ofEpochSecond((Integer) input);
+            }
+            throw new CoercingSerializeException(
+                    "Expected type 'Long' or 'Integer' but was '" + input.getClass().getSimpleName() + "'.");
+        }
+
+        @Override
+        public Instant parseLiteral(Object input) {
+            if (input instanceof IntValue) {
+                return Instant.ofEpochSecond(((IntValue) input).getValue().longValue());
+            }
+            return null;
+        }
+
     });
 
     public static GraphQLScalarType GraphQLLocalDate = new GraphQLScalarType("LocalDate", "Date type", new Coercing() {

--- a/src/test/groovy/org/crygier/graphql/JavaScalarsTest.groovy
+++ b/src/test/groovy/org/crygier/graphql/JavaScalarsTest.groovy
@@ -51,6 +51,19 @@ class JavaScalarsTest extends Specification {
         result.second == 15
     }
 
+    def 'Instant to Long'() {
+        given:
+        Coercing coercing = JavaScalars.GraphQLInstant.getCoercing()
+        final instant = Instant.now()
+
+        when:
+        def result = coercing.serialize(instant)
+
+        then:
+        result instanceof Long
+        result == instant.epochSecond
+    }
+
     def 'Long to LocalDate'() {
         given:
         Coercing coercing = JavaScalars.GraphQLLocalDate.getCoercing()


### PR DESCRIPTION
This PR supports Java8 Instant in entity. For entity with following fields:

```kotlin
@get:Column(nullable = false, insertable = false, updatable = false,
            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
var updateAt: Instant = Instant.EPOCH
```

will serialize Instant to Long:

```json
{
    "User": [
      {
        "updateAt": 1509612143
      }
    ]
}
```

I've also noticed LocalDateTime is serizlized to 
```json
{
        "createAt": {
          "dayOfYear": 180,
          "dayOfWeek": "MONDAY",
          "month": "JUNE",
          "dayOfMonth": 29,
          "year": 2015,
          "monthValue": 6,
          "hour": 16,
          "minute": 8,
          "second": 38,
          "nano": 0,
          "chronology": {
            "calendarType": "iso8601",
            "id": "ISO"
          }
        }
}
```

which makes frontend hard to use. 

Is it OK to serialize LocalDateTime to long or formatted string?
I would like to open another PR fix this.